### PR TITLE
Version change

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -35,6 +35,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
+          miniforge-version: 4.9.2-4
           use-mamba: true
           environment-file: envs/linux.yml
           use-only-tar-bz2: true
@@ -64,6 +65,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
+          miniforge-version: 4.9.2-4
           use-mamba: true
           environment-file: envs/osx.yml
           use-only-tar-bz2: true
@@ -95,6 +97,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
+          miniforge-version: 4.9.2-4
           use-mamba: true
           python-version: 3.9
           channels: conda-forge,bioconda

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -35,7 +35,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
-          miniforge-version: latest
           use-mamba: true
           environment-file: envs/linux.yml
           use-only-tar-bz2: true
@@ -65,7 +64,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
-          miniforge-version: latest
           use-mamba: true
           environment-file: envs/osx.yml
           use-only-tar-bz2: true
@@ -97,7 +95,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
-          miniforge-version: latest
           use-mamba: true
           python-version: 3.9
           channels: conda-forge,bioconda

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Apply formatting
         uses: github/super-linter@v4
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup environment
         uses: conda-incubator/setup-miniconda@v2
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup environment
         uses: conda-incubator/setup-miniconda@v2
@@ -91,7 +91,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup environment
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
@@ -94,7 +94,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - openmpi
     - pandas >=1.1.4
     - python =3.9
-    - rdkit <=2022.09.1
+    - rdkit >=2023.09.1
     - snakemake >=6.3.0
     - statsmodels >=0.11.1
     - xtb >=6.5.1

--- a/envs/linux.yml
+++ b/envs/linux.yml
@@ -13,7 +13,7 @@ dependencies:
   - openbabel >=3.0.0
   - openmpi
   - pandas >=1.1.4
-  - python >=3.9
+  - python =3.9
   - rdkit >=2023.09.1
   - snakemake >=6.3.0
   - statsmodels >=0.11.1

--- a/envs/linux.yml
+++ b/envs/linux.yml
@@ -14,7 +14,7 @@ dependencies:
   - openmpi
   - pandas >=1.1.4
   - python >=3.9
-  - rdkit
+  - rdkit >=2023.09.1
   - snakemake >=6.3.0
   - statsmodels >=0.11.1
   - xtb >=6.5.1

--- a/envs/linux.yml
+++ b/envs/linux.yml
@@ -14,7 +14,7 @@ dependencies:
   - openmpi
   - pandas >=1.1.4
   - python =3.9
-  - rdkit-dev >=2023.09.1
+  - rdkit >=2023.09.1
   - snakemake >=6.3.0
   - statsmodels >=0.11.1
   - xtb >=6.5.1

--- a/envs/linux.yml
+++ b/envs/linux.yml
@@ -13,8 +13,8 @@ dependencies:
   - openbabel >=3.0.0
   - openmpi
   - pandas >=1.1.4
-  - python =3.9
-  - rdkit <=2022.09.1
+  - python >=3.9
+  - rdkit
   - snakemake >=6.3.0
   - statsmodels >=0.11.1
   - xtb >=6.5.1

--- a/envs/linux.yml
+++ b/envs/linux.yml
@@ -14,7 +14,7 @@ dependencies:
   - openmpi
   - pandas >=1.1.4
   - python =3.9
-  - rdkit >=2023.09.1
+  - rdkit-dev >=2023.09.1
   - snakemake >=6.3.0
   - statsmodels >=0.11.1
   - xtb >=6.5.1

--- a/envs/osx.yml
+++ b/envs/osx.yml
@@ -11,7 +11,7 @@ dependencies:
   - openbabel >=3.0.0
   - openmpi
   - pandas >=1.1.4
-  - python >=3.9
+  - python =3.9
   - rdkit >=2023.09.1
   - snakemake >=6.3.0
   - statsmodels >=0.11.1

--- a/envs/osx.yml
+++ b/envs/osx.yml
@@ -12,7 +12,7 @@ dependencies:
   - openmpi
   - pandas >=1.1.4
   - python >=3.9
-  - rdkit
+  - rdkit >=2023.09.1
   - snakemake >=6.3.0
   - statsmodels >=0.11.1
   - xtb >=6.5.1

--- a/envs/osx.yml
+++ b/envs/osx.yml
@@ -12,7 +12,7 @@ dependencies:
   - openmpi
   - pandas >=1.1.4
   - python =3.9
-  - rdkit >=2023.09.1
+  - rdkit-dev >=2023.09.1
   - snakemake >=6.3.0
   - statsmodels >=0.11.1
   - xtb >=6.5.1

--- a/envs/osx.yml
+++ b/envs/osx.yml
@@ -12,7 +12,7 @@ dependencies:
   - openmpi
   - pandas >=1.1.4
   - python =3.9
-  - rdkit-dev >=2023.09.1
+  - rdkit >=2023.09.1
   - snakemake >=6.3.0
   - statsmodels >=0.11.1
   - xtb >=6.5.1

--- a/envs/osx.yml
+++ b/envs/osx.yml
@@ -11,8 +11,8 @@ dependencies:
   - openbabel >=3.0.0
   - openmpi
   - pandas >=1.1.4
-  - python =3.9
-  - rdkit <=2022.09.1
+  - python >=3.9
+  - rdkit
   - snakemake >=6.3.0
   - statsmodels >=0.11.1
   - xtb >=6.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ joblib
 numpy >= 1.19.4
 # openbabel
 pandas >= 1.1.4
-# rdkit <= 2022.09.1
+rdkit >= 2023.09.1
 snakemake >= 6.3.0
 statsmodels >= 0.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ joblib
 numpy >= 1.19.4
 # openbabel
 pandas >= 1.1.4
-rdkit >= 2023.09.1
+# rdkit >= 2023.09.1
 snakemake >= 6.3.0
 statsmodels >= 0.11.1

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     author_email='sean.colby@pnnl.gov',
     license=license,
     packages=pkgs,
-    python_requires=">=3.9",
+    python_requires="==3.9.*",
     install_requires=install_requires,
     classifiers=[
         "Intended Audience :: Science/Research",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     author_email='sean.colby@pnnl.gov',
     license=license,
     packages=pkgs,
-    python_requires="==3.9.*",
+    python_requires=">=3.9",
     install_requires=install_requires,
     classifiers=[
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
Updates RDKit requirements to fix osx-arm64 install issues (>=2023.09.1)

RDKit conda-forge feedstock fixing issue see: [conda-forge/rdkit-feedstock/pull/121](https://github.com/conda-forge/rdkit-feedstock/pull/121)

Resolves: Issue #18 

Updates GitHub actions to recent checkout, miniconda versions.
Resolves RDKit package not found error with miniforge-version restriction.